### PR TITLE
Fix gitignore audio path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,4 @@ homeassistant_config/
 
 configs/settings.yaml
 configs/
-tmp_audio/
 temp_audio/


### PR DESCRIPTION
## Summary
- drop `tmp_audio/` from `.gitignore`
- keep `temp_audio/` entry for temporary audio files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841ef29b5a0832d8e2fe94dea2a6f6d