### PR TITLE
Add openai-whisper dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,3 +69,5 @@ urllib3==2.0.7
 wadllib==1.3.6
 wheel==0.42.0
 zope.interface==6.1
+
+openai-whisper==20231106


### PR DESCRIPTION
## Summary
- add `openai-whisper` to requirements

## Testing
- `pip install openai-whisper==20231106`
- `python3 - <<'EOF'
from app import stt_engine
print('model loaded:', stt_engine.STT_MODEL is not None)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6841ef2e7f80832db7f57b7118c674d3