### PR TITLE
Add settings example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,5 +135,6 @@ ollama_data/
 homeassistant_config/
 
 configs/settings.yaml
-configs/
+configs/*
+!configs/settings.yaml.example
 temp_audio/

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This project is an exploration of what's possible with modern AI tools, local LL
 **Setup Steps:**
 1.  Clone the repository: `git clone https://github.com/nakesreong/iskra-vin.git` (Project name is Nox, repo name `iskra-vin` might be updated later)
 2.  Navigate to the project directory: `cd iskra-vin`
-3.  Create `configs/settings.yaml`. You might need to copy it from an example file if one is provided (`settings.yaml.example`) or create it manually. Fill in your API tokens (Telegram, Home Assistant), allowed user IDs, and other necessary configurations.
+3.  Copy `configs/settings.yaml.example` to `configs/settings.yaml` and fill in your API tokens (Telegram, Home Assistant), allowed user IDs, and other necessary configurations.
     **Ensure `settings.yaml` is listed in `.gitignore` to protect your secrets!**
     * Example `settings.yaml` structure:
         ```yaml
@@ -138,7 +138,7 @@ Interact with "Nox" via the Telegram bot. Send text or voice commands like:
 * **Advanced Calculator Features:**
     * Support for more complex mathematical functions (e.g., sqrt, sin, cos, log).
     * Consider a safer math expression parser than `eval()` for enhanced security if input sources expand.
-* **Create `settings.yaml.example`:** Provide a template for users.
+* **`settings.yaml.example` Template Provided:** Use this file as a starting point for your own configuration.
 * **Develop Sophisticated Dialogue Management:** For more complex, multi-turn conversations.
 * **Systemd Service / Full Dockerization:** Set up a systemd service for persistent bot operation or fully containerize the Nox application itself.
 * **Automated Testing:** Continue to implement and expand unit and integration tests (building on Codex's start, if applicable).

--- a/configs/settings.yaml.example
+++ b/configs/settings.yaml.example
@@ -1,0 +1,19 @@
+telegram_bot:
+  token: "YOUR_TELEGRAM_BOT_TOKEN"
+  allowed_user_ids:
+    - 123456789  # Example user ID
+    # - 987654321  # Another allowed ID
+ollama:
+  base_url: "http://127.0.0.1:11434"
+  default_model: "yandex/YandexGPT-5-Lite-8B-instruct-GGUF:latest"
+home_assistant:
+  base_url: "http://127.0.0.1:8123"
+  long_lived_access_token: "YOUR_HA_TOKEN"
+  default_lights:
+    - light.bulb_1
+    - light.bulb_2
+stt_engine:
+  whisper_model_size: "small"
+# logging:
+#   level: "INFO"
+#   file_path: "nox_app.log"


### PR DESCRIPTION
## Summary
- provide a template `configs/settings.yaml.example`
- tweak `.gitignore` so the example file is tracked
- update README instructions to use the example and mark TODO done

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement cloud-init==24.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68422f96cf2c832daf2e080b5e0c0c3e