### PR TITLE
Fix import comments in stt_engine

### DIFF
--- a/app/stt_engine.py
+++ b/app/stt_engine.py
@@ -2,8 +2,8 @@
 
 import whisper
 import os
-import yaml  # <--- ДОБАВЛЯЕМ ИМПОРТ YAML
-from pathlib import Path  # <--- ДОБАВЛЯЕМ ИМПОРТ PATH (если его еще нет)
+import yaml  # used for reading configuration files
+from pathlib import Path  # provides cross-platform path operations
 
 # --- Загрузка конфигурации STT (размер модели) ---
 STT_CONFIG_DATA = None


### PR DESCRIPTION
## Summary
- clean up comments on imports in `stt_engine`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68423303cb6c832daf9f799f5a28abdb