### PR TITLE
Improve handler documentation

### DIFF
--- a/app/intent_handlers/general_chat_handler.py
+++ b/app/intent_handlers/general_chat_handler.py
@@ -1,8 +1,5 @@
-# Внутри app/intent_handlers/general_chat_handler.py
 def handle_general_chat(entities: dict) -> dict:
-    # entities может содержать что-то вроде {'request_type': 'tell_joke'} или {'greeting_type': 'hello'} от NLU
-    # Мы просто передаем интент и сущности дальше, чтобы LLM сама разобралась на основе response_generation_instruction_simple
-    # Добавим лог для ясности
+    """Forward casual chat entities to the LLM and return a response."""
     print(f"GeneralChatHandler: Получены entities: {entities}")
     return {
         "success": True,  # Предполагаем, что "болтовня" всегда "успешна"

--- a/app/intent_handlers/math_operation_handler.py
+++ b/app/intent_handlers/math_operation_handler.py
@@ -4,11 +4,7 @@ import traceback  # Для вывода информации об ошибках
 
 
 def handle_math_operation(entities: dict) -> dict:
-    """
-    Handles the 'math_operation' intent.
-    Tries to evaluate the mathematical expression provided in entities.
-    Returns a dictionary with the result or an error message.
-    """
+    """Evaluate a math expression for the intent and return a result. Uses eval() on sanitized input; caution advised."""
     print(f"MathOperationHandler: Received entities: {entities}")
 
     expression_to_evaluate = entities.get("expression")
@@ -27,10 +23,6 @@ def handle_math_operation(entities: dict) -> dict:
     print(f"MathOperationHandler: Attempting to evaluate expression: '{expression_to_evaluate}'")
 
     try:
-        # ВНИМАНИЕ: Использование eval() может быть небезопасным с неконтролируемым вводом.
-        # Для нашего случая, где выражение приходит от NLU и в основном используется тобой,
-        # риск приемлем на данном этапе.
-        # В будущем можно рассмотреть более безопасные парсеры, если потребуется.
 
         # Простая проверка на наличие только разрешенных символов перед eval
         # Это очень базовая защита, не исчерпывающая!


### PR DESCRIPTION
## Summary
- document `handle_general_chat`
- tighten `handle_math_operation` docstring and drop inline eval warning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684233182848832da0d2db1ab61d4a24