### PR TITLE
Refactor tests with shared conftest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import sys
+import pytest
+
+@pytest.fixture(autouse=True, scope="session")
+def add_project_root_to_sys_path():
+    """Ensure the project root is available on sys.path for imports."""
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+    yield
+    # No cleanup required; keep path for duration of session

--- a/tests/test_light_actions.py
+++ b/tests/test_light_actions.py
@@ -1,21 +1,17 @@
 import importlib
-import os
-import sys
 from unittest import mock
 
 import pytest
 
-# Ensure project root is in sys.path for module resolution
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, PROJECT_ROOT)
 
-# Import the light_actions module fresh to ensure config loading runs
-light_actions = importlib.import_module('app.actions.light_actions')
+@pytest.fixture(scope="module")
+def light_actions(add_project_root_to_sys_path):
+    """Import the light_actions module after sys.path is prepared."""
+    return importlib.import_module('app.actions.light_actions')
 
 
 @pytest.fixture(autouse=True)
-def fake_config(monkeypatch):
+def fake_config(monkeypatch, light_actions):
     """Provide fake Home Assistant configuration for tests."""
     monkeypatch.setattr(light_actions, "HA_URL", "http://ha.test")
     monkeypatch.setattr(light_actions, "HA_TOKEN", "TOKEN")
@@ -23,7 +19,7 @@ def fake_config(monkeypatch):
 
 
 @pytest.fixture
-def mock_post(monkeypatch):
+def mock_post(monkeypatch, light_actions):
     """Mock requests.post used by light_actions."""
     mock_response = mock.Mock(status_code=200, text="ok")
     mock_response.raise_for_status = mock.Mock()
@@ -32,31 +28,31 @@ def mock_post(monkeypatch):
     return post_mock
 
 
-def test_turn_on_invalid_brightness_low():
+def test_turn_on_invalid_brightness_low(light_actions):
     result = light_actions.turn_on(brightness_percent=-1)
     assert result["success"] is False
     assert "Яркость" in result.get("error", "")
 
 
-def test_turn_on_invalid_brightness_high():
+def test_turn_on_invalid_brightness_high(light_actions):
     result = light_actions.turn_on(brightness_percent=101)
     assert result["success"] is False
     assert "Яркость" in result.get("error", "")
 
 
-def test_set_color_temperature_invalid_string():
+def test_set_color_temperature_invalid_string(light_actions):
     result = light_actions.set_color_temperature("hot")
     assert result["success"] is False
     assert "Неизвестное значение" in result.get("error", "")
 
 
-def test_set_color_temperature_invalid_numeric():
+def test_set_color_temperature_invalid_numeric(light_actions):
     result = light_actions.set_color_temperature(900)
     assert result["success"] is False
     assert "температуры" in result.get("error", "")
 
 
-def test_turn_on_calls_correct_endpoint(mock_post):
+def test_turn_on_calls_correct_endpoint(mock_post, light_actions):
     result = light_actions.turn_on(entity_ids=["light.custom"], brightness_percent=75)
     assert result["success"] is True
     expected_url = "http://ha.test/api/services/light/turn_on"
@@ -70,7 +66,7 @@ def test_turn_on_calls_correct_endpoint(mock_post):
     )
 
 
-def test_turn_off_calls_correct_endpoint_with_default(mock_post):
+def test_turn_off_calls_correct_endpoint_with_default(mock_post, light_actions):
     result = light_actions.turn_off()
     assert result["success"] is True
     expected_url = "http://ha.test/api/services/light/turn_off"
@@ -82,3 +78,4 @@ def test_turn_off_calls_correct_endpoint_with_default(mock_post):
     mock_post.assert_called_once_with(
         expected_url, headers=expected_headers, json=expected_payload, timeout=10
     )
+

--- a/tests/test_math_operation_handler.py
+++ b/tests/test_math_operation_handler.py
@@ -1,45 +1,44 @@
 import importlib
-import os
-import sys
-
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, PROJECT_ROOT)
-
-math_handler = importlib.import_module('app.intent_handlers.math_operation_handler')
+import pytest
 
 
-def test_valid_expression_addition():
+@pytest.fixture(scope="module")
+def math_handler(add_project_root_to_sys_path):
+    return importlib.import_module('app.intent_handlers.math_operation_handler')
+
+
+def test_valid_expression_addition(math_handler):
     result = math_handler.handle_math_operation({'expression': '2 + 3 * 4'})
     assert result['success'] is True
     assert result['result'] == 14
 
 
-def test_valid_expression_integer_conversion():
+def test_valid_expression_integer_conversion(math_handler):
     result = math_handler.handle_math_operation({'expression': '6 / 3'})
     assert result['success'] is True
     assert result['result'] == 2
 
 
-def test_disallowed_characters():
+def test_disallowed_characters(math_handler):
     result = math_handler.handle_math_operation({'expression': '2 + two'})
     assert result['success'] is False
     assert 'disallowed characters' in result['details_or_error'].lower()
 
 
-def test_zero_division_error():
+def test_zero_division_error(math_handler):
     result = math_handler.handle_math_operation({'expression': '10 / 0'})
     assert result['success'] is False
     assert result.get('error_type') == 'ZeroDivisionError'
 
 
-def test_syntax_error():
+def test_syntax_error(math_handler):
     result = math_handler.handle_math_operation({'expression': '10 /'})
     assert result['success'] is False
     assert result.get('error_type') == 'SyntaxError'
 
 
-def test_missing_expression():
+def test_missing_expression(math_handler):
     result = math_handler.handle_math_operation({})
     assert result['success'] is False
     assert result['action_performed'] == 'math_calculation_error'
+


### PR DESCRIPTION
## Summary
- add `tests/conftest.py` with a session-scoped fixture that inserts the project root into `sys.path`
- refactor each test module to use fixtures and remove duplicated setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426359b46c832d81f07ff19ba99ba7